### PR TITLE
Fix wrong sysroot src path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "rust-analyzer.linkedProjects": [
         {
-            "sysroot_src": "/home/matklad/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src",
+            "sysroot_src": "/home/matklad/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library",
             "crates": [
                 {
                     "root_module": "src/main.rs",


### PR DESCRIPTION
The previous one was wrong:

```
 » ls ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/src 
llvm-project
```

Whereas,

```
 » ls ~/.rustup/toolchains/nightly-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library
alloc  backtrace  core  panic_abort  panic_unwind  proc_macro  profiler_builtins  rtstartup  rustc-std-workspace-alloc  rustc-std-workspace-core  rustc-std-workspace-std  std  stdarch  term  test  unwind
```