### PR TITLE
Add dependency file and compile script

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,6 +6,14 @@
                 {
                     "root_module": "src/main.rs",
                     "edition": "2018",
+                    "deps": [{
+                        "crate": 1,
+                        "name": "hello",
+                    }],
+                },
+                {
+                    "root_module": "include/hello.rs",
+                    "edition": "2018",
                     "deps": [],
                 },
             ]

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,2 @@
+rustc --crate-type=lib include/hello.rs
+rustc --extern hello=libhello.rlib src/main.rs

--- a/include/hello.rs
+++ b/include/hello.rs
@@ -1,0 +1,4 @@
+/// prints a hello world message
+pub fn print_hello() {
+    println!("Hello World!");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-fn foo() {}
 fn main() {
-    std::asm!()
-    println!("Hello, world!");
+    std::assert!(true);
+    hello::print_hello();
 }


### PR DESCRIPTION
The current example is fairly bare-bones. Adding some files to address questions that I had when looking up how the rust-project.json file worked.

1) Added a dependency file "hello.rs" that is pulled in by main.rs. Updated settings.json to mark hello.rs as a dependency. Now people can see how "deps" should work.
2) Added a compile script "compile.sh" that works on linux and just uses rustc. This kind of makes this a real functional project by showing how to compile the code, since we are assuming any client altering rust-project.json will not be using cargo in the normal sense.
3) Added fixes to main.rs since it didn't seem to compile on my machine. Specifically, asm!() was not in std. std::assert! should be more reliable.